### PR TITLE
add script to relax plugin api dependency + some core tweaks

### DIFF
--- a/lib/logstash/mass_effect/repository.rb
+++ b/lib/logstash/mass_effect/repository.rb
@@ -177,7 +177,7 @@ module LogStash
         puts "size after: #{repositories.size}"
 
         repositories.each do |repository|
-          repository = clone(repository[:git_url], File.join(target, repository[:name]))
+          repository = clone(repository[:clone_url], File.join(target, repository[:name]))
         end
       end
 

--- a/scripts/helpers.rb
+++ b/scripts/helpers.rb
@@ -1,10 +1,12 @@
+require 'pathname'
+
 TARGET_PATH = "./tmp"
 
-def update_changelog(text)
-  edit_matched_files("*/CHANGELOG.md") do |content|
+def update_changelog(text, match = "*/CHANGELOG.md")
+  edit_matched_files(match) do |content|
     content.shift(text)
     version = content.read_version
-    content.shift("# #{version}\n")
+    content.shift("## #{version}\n")
     content.save
   end
 end
@@ -14,7 +16,11 @@ end
 # handy for doing condition on the version of the specific plugin
 def edit_matched_files(*match, &block)
   match.each do |m|
-    path = File.join(File.expand_path(TARGET_PATH), m)
+    if Pathname.new(m).absolute?
+      path = m
+    else
+      path = File.join(File.expand_path(TARGET_PATH), m)
+    end
     puts "path: #{path}"
 
     Dir.glob(path).each do |file|

--- a/scripts/logstash-core-plugin-api-1.60.rb
+++ b/scripts/logstash-core-plugin-api-1.60.rb
@@ -1,0 +1,44 @@
+require_relative "helpers"
+
+def relax_plugin_api_dependency(content)
+  # turn:
+  #   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
+  # into:
+  #   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  content.gsub!(/add_runtime_dependency ["']logstash-core-plugin-api["'].+2\.0.+/, 'add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"')
+end
+
+def bump_version(gemspec_content)
+  versions_parts = gemspec_content.match(/s\.version\s+=\s['"](\d+)\.(\d+)\.(\d+)['"]/).to_a
+  gemspec_content.gsub!(/s\.version\s+=\s['"]\d+\.\d+\.\d+['"]/, "s.version         = '#{versions_parts[1]}.#{versions_parts[2]}.#{versions_parts[3].to_i + 1}'")
+end
+
+
+Dir.glob(File.join(File.expand_path('./tmp'), '**/*.gemspec')).each do |gemspec|
+  content = File.read(gemspec)
+
+  changed_content = content.dup
+  bump_version(changed_content)
+  if content == changed_content
+    puts "failed to process stage 1 of #{gemspec}, skipping"
+    next
+  else
+    content = changed_content
+  end
+
+  changed_content = content.dup
+  relax_plugin_api_dependency(changed_content)
+  if content == changed_content
+    puts "failed to process stage 2 of #{gemspec}, skipping"
+    next
+  else
+    content = changed_content
+  end
+
+  File.open(gemspec, "w+") { |f| f.write(content) }
+
+  changelog_content = "  - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99\n\n"
+  changelog_path = File.join(gemspec.split("\/")[0...-1] << "CHANGELOG.md")
+  update_changelog(changelog_content, changelog_path)
+end
+


### PR DESCRIPTION
* change update_changelog to accept a file path
* use clone_url instead of git_url when cloning repos for mass push,
  since git_url is read only.
* add `scripts/logstash-core-plugin-api-1.60.rb` that relaxes all plugins constraint
  on logstash-core-plugin-api